### PR TITLE
Switching over to pekko-http

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,9 @@
 Compile / guardrailTasks := List(
-  ScalaServer(file("petstore.yaml"), pkg="foo"),
+  ScalaServer(file("petstore.yaml"), pkg="foo", modules=List("pekko-http", "circe")),
 )
 
-val akkaVersion       = "2.6.20"
-val akkaHttpVersion   = "10.2.10"
+val pekkoVersion      = "1.0.0"
+val pekkoHttpVersion  = "1.0.0"
 val catsVersion       = "2.6.1"
 val circeVersion      = "0.14.1"
 val scalatestVersion  = "3.2.9"
@@ -14,14 +14,14 @@ scalacOptions ++= Seq("-Ypartial-unification", "-deprecation")
 libraryDependencies += "org.slf4j" % "slf4j-simple" % "1.7.30"
 
 libraryDependencies ++= Seq(
-  "com.typesafe.akka" %% "akka-actor"        % akkaVersion,
-  "com.typesafe.akka" %% "akka-stream"       % akkaVersion,
-  "com.typesafe.akka" %% "akka-http"         % akkaHttpVersion,
-  "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpVersion,
-  "io.circe"          %% "circe-core"        % circeVersion,
-  "io.circe"          %% "circe-generic"     % circeVersion,
-  "io.circe"          %% "circe-parser"      % circeVersion,
-  "javax.xml.bind"    %  "jaxb-api"          % jaxbApiVersion,
-  "org.scalatest"     %% "scalatest"         % scalatestVersion % Test,
-  "org.typelevel"     %% "cats-core"         % catsVersion,
+  "org.apache.pekko"  %% "pekko-http"          % pekkoHttpVersion,
+  "org.apache.pekko"  %% "pekko-http-testkit"  % pekkoHttpVersion,
+  "org.apache.pekko"  %% "pekko-stream"        % pekkoVersion,
+  "org.apache.pekko"  %% "pekko-testkit"       % pekkoVersion,
+  "io.circe"          %% "circe-core"          % circeVersion,
+  "io.circe"          %% "circe-generic"       % circeVersion,
+  "io.circe"          %% "circe-parser"        % circeVersion,
+  "javax.xml.bind"    %  "jaxb-api"            % jaxbApiVersion,
+  "org.scalatest"     %% "scalatest"           % scalatestVersion % Test,
+  "org.typelevel"     %% "cats-core"           % catsVersion,
 )

--- a/project/guardrail.sbt
+++ b/project/guardrail.sbt
@@ -1,1 +1,9 @@
-addSbtPlugin("dev.guardrail" % "sbt-guardrail" % "0.75.2")
+addSbtPlugin("dev.guardrail" % "sbt-guardrail" % "1.0.0-SNAPSHOT")
+
+libraryDependencies ++= Seq(
+  "dev.guardrail" %% "guardrail-scala-pekko-http" % "0.1.0-SNAPSHOT",
+  "dev.guardrail" %% "guardrail-core" % "1.0.0-SNAPSHOT",
+  "dev.guardrail" %% "guardrail-scala-support" % "1.0.0-SNAPSHOT",
+)
+
+resolvers += "Sonatype OSS Snapshots" at "https://s01.oss.sonatype.org/content/repositories/snapshots"

--- a/src/main/scala/App.scala
+++ b/src/main/scala/App.scala
@@ -2,9 +2,9 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent._
 import scala.concurrent.duration.Duration
 
-import akka.actor.ActorSystem
-import akka.http.scaladsl.Http
-import akka.http.scaladsl.model.ContentType
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.Http
+import org.apache.pekko.http.scaladsl.model.ContentType
 
 import foo.pet._
 import foo.definitions.Pet


### PR DESCRIPTION
A functional example of switching over from the akka-http module to the pekko-http module.

Note, the pekko module is currently prerelease, only offered as a SNAPSHOT.
Please contact [`hello@guardrail.dev`](mailto:hello@guardrail.dev) if you need a more stable release for any reason.